### PR TITLE
return json response properly

### DIFF
--- a/dribbble/api.py
+++ b/dribbble/api.py
@@ -16,7 +16,7 @@ def get(url, **params):
         count = params.pop('count')
         params['per_page'] = count
     response = req.get(url, params=params)
-    return response.json
+    return response.json()
 
 
 def comments(number, **params):


### PR DESCRIPTION
Was getting `<bound method Response.json of <Response [200]>>`, this pull request returns the JSON properly.
